### PR TITLE
Prevent locks from becoming mutually exclusive

### DIFF
--- a/server.go
+++ b/server.go
@@ -277,7 +277,11 @@ func onDisconnectCleanup(c *Channel) {
 
 		delete(c.server.rooms, c)
 	}
+	
+	go deleteSid(c)
+}
 
+func deleteSid(c *Channel) {
 	c.server.sidsLock.Lock()
 	defer c.server.sidsLock.Unlock()
 


### PR DESCRIPTION
Through some profiling under a fair amount of load, we found that on occasion the sidsLock would not release and cause channelsLock not not release as well since both are deferred. After offloading it to another goroutine, the issue subsided under load.